### PR TITLE
Various bug fixes/tweaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
+## 1.2.2
+
+- Dropped items on Jester should now attach properly (v56 compatibility)
+- Items can no longer be placed on Jester while inside the ship
+	- Should prevent Jester sneaking under the ship and stealing items in some custom moons
+- Fixed error when removing items from the Jester through iteration
+- Coilhead's head scale reduced to 0.2
+
 ## 1.2.1
 
 - Added Head scrap item
-- Colheads now drops it's head on death
+- Coilheads now drops its head on death
 - Fixed Coilhead's head disappear only for host bug
 
 ## 1.2.0

--- a/MoreCounterplay.csproj
+++ b/MoreCounterplay.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <!-- BepInEx Properties -->
     <PropertyGroup>
         <AssemblyName>BaronDrakula.MoreCounterplay</AssemblyName>
         <Product>MoreCounterplay</Product>
         <!-- Change to whatever version you're currently on. -->
-        <Version>1.2.1</Version>
+        <Version>1.2.2</Version>
     </PropertyGroup>
 
     <!-- Project Properties -->

--- a/Patches/CoilheadPatch.cs
+++ b/Patches/CoilheadPatch.cs
@@ -79,6 +79,10 @@ namespace MoreCounterplay.Patches
         public static void SpawnHead(Vector3 spawnPosition)
         {
             if (!ConfigSettings.DropHeadAsScrap.Value) return;
+
+            // Scale Coilhead scrap item down.
+            MoreCounterplay.HeadItem.spawnPrefab.transform.localScale = new Vector3(0.2f, 0.2f, 0.2f);
+
             var headItem = GameObject.Instantiate(MoreCounterplay.HeadItem.spawnPrefab, spawnPosition, Quaternion.identity);
             headItem.GetComponentInChildren<GrabbableObject>().SetScrapValue(Random.Range(ConfigSettings.MinHeadValue.Value, ConfigSettings.MaxHeadValue.Value));
             headItem.GetComponentInChildren<NetworkObject>().Spawn();


### PR DESCRIPTION
## [1.2.2]
- Dropped items on Jester should now attach properly (v56 compatibility).
  - #6
- Items can no longer be placed on Jester while inside the ship.
  - Should prevent Jester sneaking under the ship and stealing items in some custom moons.
- Fixed error when removing items from the Jester through iteration.
- Coilhead's head scale reduced to '0.2'.
  - #1

---

Not tested in multiplayer, but everything seems to be working properly. Let me know if there's any issues, though!