### PR TITLE
Minor fixes for Coilhead features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.2.3
+
+- Coilhead's head item should no longer vanish from the ship after reloading the save file
+- Coilhead's head item now spawns properly attached and facing the right way
+- Coilhead's head item no longer floats above the ground when dropped/placed, and is upright
+	- This also made it able to be properly placed inside the storage cabinet
+- Coilhead's head item scale further reduced to 0.1763
+	- Matches the size of the actual head
+- Coilhead should no longer get stuck in its moving animation if killed while moving
+	- Could happen previously while walking backwards into it while swinging the knife
+- Coilhead's neck now wobbles one final time when killed, to indicate its death
+
 ## 1.2.2
 
 - Dropped items on Jester should now attach properly (v56 compatibility)
@@ -9,7 +21,7 @@
 ## 1.2.1
 
 - Added Head scrap item
-- Coilheads now drops its head on death
+- Coilheads now drop their head on death
 - Fixed Coilhead's head disappear only for host bug
 
 ## 1.2.0

--- a/MoreCounterplay.cs
+++ b/MoreCounterplay.cs
@@ -39,6 +39,14 @@ public class MoreCounterplay : BaseUnityPlugin
 
         HeadItem = Bundle.LoadAsset<Item>("Head.asset");
 
+        // Head size, position, and rotation adjustments.
+        HeadItem.itemSpawnsOnGround = false;
+        HeadItem.restingRotation = new Vector3(-90, 0, 90);
+        HeadItem.spawnPrefab.transform.localScale = new Vector3(0.1763f, 0.1763f, 0.1763f);
+        HeadItem.spawnPrefab.transform.rotation *= Quaternion.Euler(-90f, 0f, 0f);
+        HeadItem.verticalOffset = 0.1f;
+
+        LethalLib.Modules.Items.RegisterItem(HeadItem); // Register as a plain item to persist when reloading the save file.
         LethalLib.Modules.NetworkPrefabs.RegisterNetworkPrefab(HeadItem.spawnPrefab);
     }
 

--- a/MoreCounterplay.csproj
+++ b/MoreCounterplay.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>BaronDrakula.MoreCounterplay</AssemblyName>
         <Product>MoreCounterplay</Product>
         <!-- Change to whatever version you're currently on. -->
-        <Version>1.2.2</Version>
+        <Version>1.2.3</Version>
     </PropertyGroup>
 
     <!-- Project Properties -->
@@ -13,7 +13,7 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <RootNamespace>MoreCounterplay</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>preview</LangVersion>
     </PropertyGroup>
 
     <!-- Enable Nullable for better IDE null-checking -->
@@ -43,6 +43,7 @@
     <!-- Primary Package References -->
     <ItemGroup>
         <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
+        <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" PrivateAssets="all" />
         <PackageReference Include="BepInEx.Core" Version="5.*" PrivateAssets="all" />
         <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" PrivateAssets="all" />
         <PackageReference Include="LethalCompany.GameLibs.Steam" Version="*-*" PrivateAssets="all" />
@@ -56,7 +57,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Reference Include="Assembly-CSharp">
+      <Reference Include="Assembly-CSharp" Publicize="true">
         <HintPath>lib\Assembly-CSharp.dll</HintPath>
       </Reference>
     </ItemGroup>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "MoreCounterplay",
-  "version_number": "1.2.2",
+  "version_number": "1.2.3",
   "website_url": "https://github.com/karyol/More-Counterplay-Mod",
   "description": "More counterplay for some Lethal Company mobs",
   "dependencies": [


### PR DESCRIPTION
## [1.2.3]
- Coilhead's head item should no longer vanish from the ship after reloading the save file.
	- #2
- Coilhead's head item now spawns properly attached and facing the right way.
- Coilhead's head item no longer floats above the ground when dropped/placed, and is upright.
	- This also made it able to be properly placed inside the storage cabinet.
- Coilhead's head item scale further reduced to `0.1763`.
	- Matches the size of the actual head.
- Coilhead should no longer get stuck in its moving animation if killed while moving.
	- Could happen previously while walking backwards into it while swinging the knife.
- Coilhead's neck now wobbles one final time when killed, to indicate its death.
- (Project) Publicized game assembly (to access certain fields and methods from `SpringManAI`).
- (Project) Changed language version to `preview` to enable collection literals.