### PR TITLE
Further configuration added to Coilheads, minor visual fix.

### DIFF
--- a/Behaviours/CoilExplosion.cs
+++ b/Behaviours/CoilExplosion.cs
@@ -127,7 +127,8 @@ namespace MoreCounterplay.Behaviours
 		private void PlaySfxClientRpc()
 		{
 			// Play unused 'Spring1.ogg' sound effect, or 'EnterCooldown.ogg' sound effect if the former is not found.
-			Coilhead?.creatureVoice.PlayOneShot(HeadItem.Prefab?.GetComponent<HeadItem>().itemProperties.throwSFX ?? Coilhead?.enterCooldownSFX);
+			Coilhead?.creatureVoice.PlayOneShot(HeadItem.Prefab?.GetComponent<HeadItem>().itemProperties.throwSFX ?? Coilhead?.enterCooldownSFX,
+				MoreCounterplay.Settings.ExplosionWarnVolume.Value);
 		}
 
 		/// <summary>
@@ -137,13 +138,19 @@ namespace MoreCounterplay.Behaviours
 		[ClientRpc]
 		internal void UpdateScanNodeClientRpc(bool ignited)
 		{
+			// Return if not re-enabling the Coilhead scan node.
+			if (!MoreCounterplay.Settings.ModifyCoilheadScanNode.Value) return;
+
 			// Obtain and re-enable scan node.
 			ScanNodeProperties scanNode = transform.Find("SpringManModel/ScanNode").GetComponent<ScanNodeProperties>();
 			scanNode.GetComponent<Collider>().enabled = true;
 
+			// Return if not making any further changes to the Coilhead scan node.
+			if (!MoreCounterplay.Settings.ModifyCoilheadScanNode.Value) return;
+
 			// Update scan node to match current state.
 			scanNode.headerText = $"{(ignited ? "Fissile" : "Decayed")} Coil-Head";
-			scanNode.subText = ignited ? "Run." : "I wouldn't get close...";
+			scanNode.subText = ignited ? "Run." : "Don't get too close...";
 			scanNode.nodeType = ignited ? 1 : 0;
 		}
 	}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.1
+
+- Added several client-sided configuration settings for "lore accurate" Coilheads
+- Fixed "lore accurate" Coilhead particle effects not showing up after reloading a lobby once
+- Split configuration file entries into categories based on their respective entities
+
 ## 1.3.0
 
 <ul>

--- a/Config/ConfigSettings.cs
+++ b/Config/ConfigSettings.cs
@@ -29,6 +29,7 @@ namespace MoreCounterplay.Config
         [field: SyncedEntryField] public SyncedEntry<bool> DropHeadAsScrap { get; private set; }
         [field: SyncedEntryField] public SyncedEntry<int> MinHeadValue { get; private set; }
         [field: SyncedEntryField] public SyncedEntry<int> MaxHeadValue { get; private set; }
+
         [field: SyncedEntryField] public SyncedEntry<bool> LoreAccurateCoilheads { get; private set; }
         [field: SyncedEntryField] public SyncedEntry<int> ExplosionDamage { get; private set; }
         [field: SyncedEntryField] public SyncedEntry<float> ExplosionDamageRadius { get; private set; }
@@ -36,6 +37,12 @@ namespace MoreCounterplay.Config
         [field: SyncedEntryField] public SyncedEntry<float> MinExplosionTimer { get; private set; }
         [field: SyncedEntryField] public SyncedEntry<float> MaxExplosionTimer { get; private set; }
         [field: SyncedEntryField] public SyncedEntry<bool> ExplosionDestroysHead { get; private set; }
+
+        public ConfigEntry<bool> ExplosionFire { get; private set; }
+        public ConfigEntry<bool> ExplosionParticles { get; private set; }
+        public ConfigEntry<float> ExplosionWarnVolume { get; private set; }
+        public ConfigEntry<bool> EnableCoilheadScanNode { get; private set; }
+        public ConfigEntry<bool> ModifyCoilheadScanNode { get; private set; }
         #endregion
         #endregion
 
@@ -45,31 +52,38 @@ namespace MoreCounterplay.Config
             config.SaveOnConfigSet = false;
 
             #region Jester
-            EnableJesterCounterplay = config.BindSyncedEntry("Server-side", "EnableJesterCounterplay", true, "Add counterplay for Jester.");
-            WeightToPreventJester = config.BindSyncedEntry("Server-side", "WeightToPreventJester", 30f, "Weight of items needed to prevent Jester pop out.");
+            EnableJesterCounterplay = config.BindSyncedEntry("Jester", "EnableJesterCounterplay", true, "Add counterplay for Jester.");
+            WeightToPreventJester = config.BindSyncedEntry("Jester", "WeightToPreventJester", 30f, "Weight of items needed to prevent Jester pop out.");
             #endregion
 
             #region Turret
-            EnableTurretCounterplay = config.BindSyncedEntry("Server-side", "EnableTurretCounterplay", true, "Add counterplay for Turret.");
+            EnableTurretCounterplay = config.BindSyncedEntry("Turret", "EnableTurretCounterplay", true, "Add counterplay for Turret.");
             #endregion
 
             #region Coilhead
-            EnableCoilheadCounterplay = config.BindSyncedEntry("Server-side", "EnableCoilheadCounterplay", true, "Add counterplay for Coilheads (requires restart). Required by settings below.");
-            SpringDurability = config.BindSyncedEntry("Server-side", "SpringDurability", 3, "Set Coilhead health points (requires restart).");
-            CoilheadDefaultDamage = config.BindSyncedEntry("Server-side", "CoilheadDefaultDamage", 0, "Amount of damage that Coilheads take from any source not specified below.");
-            CoilheadKnifeDamage = config.BindSyncedEntry("Server-side", "CoilheadKnifeDamage", 1, "Amount of damage that Coilheads take from Knife.");
-            CoilheadShovelDamage = config.BindSyncedEntry("Server-side", "CoilheadShovelDamage", 0, "Amount of damage that Coilheads take from Shovel.");
-            DropHeadAsScrap = config.BindSyncedEntry("Server-side", "DropHeadAsScrap", true, "Enable the Coilhead head scrap item spawning on death (requires restart).");
-            MinHeadValue = config.BindSyncedEntry("Server-side", "MinHeadValue", 30, "Minimum value of the Coilhead head item.");
-            MaxHeadValue = config.BindSyncedEntry("Server-side", "MaxHeadValue", 70, "Maximum value of the Coilhead head item.");
+            EnableCoilheadCounterplay = config.BindSyncedEntry("Coilhead", "EnableCoilheadCounterplay", true, "Add counterplay for Coilheads. Required for all Coilhead settings under this.");
+            SpringDurability = config.BindSyncedEntry("Coilhead", "SpringDurability", 3, "Set Coilhead health points.");
+            CoilheadDefaultDamage = config.BindSyncedEntry("Coilhead", "CoilheadDefaultDamage", 0, "Amount of damage that Coilheads take from any source not specified below.");
+            CoilheadKnifeDamage = config.BindSyncedEntry("Coilhead", "CoilheadKnifeDamage", 1, "Amount of damage that Coilheads take from Knife.");
+            CoilheadShovelDamage = config.BindSyncedEntry("Coilhead", "CoilheadShovelDamage", 0, "Amount of damage that Coilheads take from Shovel.");
+            DropHeadAsScrap = config.BindSyncedEntry("Coilhead", "DropHeadAsScrap", true, "Enable the Coilhead head scrap item spawning on death.");
+            MinHeadValue = config.BindSyncedEntry("Coilhead", "MinHeadValue", 30, "Minimum value of the Coilhead head item.");
+            MaxHeadValue = config.BindSyncedEntry("Coilhead", "MaxHeadValue", 70, "Maximum value of the Coilhead head item.");
 
-            LoreAccurateCoilheads = config.BindSyncedEntry("Server-side", "LoreAccurateCoilheads", true, "Enable lore accurate (volatile) Coilhead counterplay (requires restart). Required by settings below.");
-            ExplosionDamage = config.BindSyncedEntry("Server-side", "ExplosionDamage", 50, "Amount of damage the Coilhead explosion deals.");
-            ExplosionDamageRadius = config.BindSyncedEntry("Server-side", "ExplosionDamageRadius", 4f, "Radius of the Coilhead explosion damage zone.");
-            ExplosionKillRadius = config.BindSyncedEntry("Server-side", "ExplosionKillRadius", 2f, "Radius of the Coilhead explosion kill zone.");
-            MinExplosionTimer = config.BindSyncedEntry("Server-side", "MinExplosionTimer", 0.5f, "Minimum time until Coilhead explosion.");
-            MaxExplosionTimer = config.BindSyncedEntry("Server-side", "MaxExplosionTimer", 5f, "Maximum time until Coilhead explosion.");
-            ExplosionDestroysHead = config.BindSyncedEntry("Server-side", "ExplosionDestroysHead", true, "Destroy Coilhead scrap head if still attached during explosion.");
+            LoreAccurateCoilheads = config.BindSyncedEntry("Coilhead", "LoreAccurateCoilheads", true, "Enable lore accurate (volatile) Coilhead counterplay (requires restart). Required for all Coilhead settings under this.");
+            ExplosionDamage = config.BindSyncedEntry("Coilhead", "ExplosionDamage", 50, "Amount of damage the Coilhead explosion deals.");
+            ExplosionDamageRadius = config.BindSyncedEntry("Coilhead", "ExplosionDamageRadius", 4f, "Radius of the Coilhead explosion damage zone.");
+            ExplosionKillRadius = config.BindSyncedEntry("Coilhead", "ExplosionKillRadius", 2f, "Radius of the Coilhead explosion kill zone.");
+            MinExplosionTimer = config.BindSyncedEntry("Coilhead", "MinExplosionTimer", 0.5f, "Minimum time until Coilhead explosion.");
+            MaxExplosionTimer = config.BindSyncedEntry("Coilhead", "MaxExplosionTimer", 5f, "Maximum time until Coilhead explosion.");
+            ExplosionDestroysHead = config.BindSyncedEntry("Coilhead", "ExplosionDestroysHead", true, "Destroy Coilhead scrap head if still attached during explosion.");
+
+            ExplosionFire = config.Bind("Coilhead", "ExplosionFire", true, "(Client-side) Enable green fire effect for Coilheads that are about to explode.");
+            ExplosionParticles = config.Bind("Coilhead", "ExplosionParticles", true, "(Client-side) Enable radioactive particles effect for Coilheads that are about to explode.");
+            ExplosionWarnVolume = config.Bind("Coilhead", "ExplosionWarnVolume", 1.0f, new ConfigDescription("(Client-side) Adjust volume of the sound effect played right before exploding (NOT the actual explosion).",
+                new AcceptableValueRange<float>(0.0f, 1.0f)));
+            EnableCoilheadScanNode = config.Bind("Coilhead", "EnableCoilheadScanNode", true, "(Client-side) Enable scanning Coilheads that have been killed.");
+            ModifyCoilheadScanNode = config.Bind("Coilhead", "ModifyCoilheadScanNode", true, "(Client-side) Add extra text/subtext to a killed Coilhead's scan node.");
             #endregion
 
             // Function to run after configuration is synced (upon joining lobby).

--- a/Items/HeadItem.cs
+++ b/Items/HeadItem.cs
@@ -62,7 +62,7 @@ namespace MoreCounterplay.Items
 			if (coilheadReference.TryGet(out NetworkObject coilheadNetworkObject))
 			{
 				// Obtain Coilhead's head prefab.
-				GameObject originalHead = coilheadNetworkObject.gameObject.transform.Find("SpringManModel/Head").gameObject;
+				GameObject originalHead = coilheadNetworkObject.transform.Find("SpringManModel/Head").gameObject;
 
 				// Attach head scrap item to original head object.
 				AttachTo(originalHead);

--- a/MoreCounterplay.csproj
+++ b/MoreCounterplay.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>BaronDrakula.MoreCounterplay</AssemblyName>
         <Product>MoreCounterplay</Product>
         <!-- Change to whatever version you're currently on. -->
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
     </PropertyGroup>
 
     <!-- Project Properties -->

--- a/Patches/CoilheadPatch.cs
+++ b/Patches/CoilheadPatch.cs
@@ -127,7 +127,7 @@ namespace MoreCounterplay.Patches
             if (!MoreCounterplay.Settings.LoreAccurateCoilheads) return;
 
             // Enable radioactive fire particle effects.
-            coilhead.gameObject.transform.Find("SpringManModel/RadioactiveFire")?.gameObject.SetActive(true);
+            coilhead.transform.Find("SpringManModel/RadioactiveFire")?.gameObject.SetActive(true);
 
             // Activate behaviour script only when called from the server.
             if (!coilhead.IsServer && !coilhead.IsHost) return;

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ You can cut off a Coilhead's head using a knife. Its head will become a scrap it
   - Minimum and maximum time until exploding can be configured via the `MinExplosionTimer` and `MaxExplosionTimer` settings, respectively
 - Coilhead's head item is destroyed if its body explodes while it's still attached to its neck
   - Can be disabled by toggling the `ExplosionDestroysHead` setting, but it adds some interesting risk/reward by making players stay close to try and pick up the head before it explodes
+- Client-side configuration settings:
+  - `ExplosionFire` - Enable green fire effect for Coilheads that are about to explode
+  - `ExplosionParticles` - Enable radioactive particles effect for Coilheads that are about to explode
+  - `ExplosionWarnVolume` - Adjust volume of the sound effect played right before exploding (**NOT** the actual explosion)
+  - `EnableCoilheadScanNode` - Enable scanning Coilheads that have been killed
+  - `ModifyCoilheadScanNode` - Add extra text/subtext to a killed Coilhead's scan node (requires `EnableCoilheadScanNode`)
 
  </div>
  </details>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "MoreCounterplay",
-  "version_number": "1.3.0",
+  "version_number": "1.3.1",
   "website_url": "https://github.com/karyol/More-Counterplay-Mod",
   "description": "More counterplay for some Lethal Company mobs",
   "dependencies": [


### PR DESCRIPTION
## [1.3.1]
- Split configuration file entries into categories based on their respective entities.
- Added several client-sided configuration settings for "lore accurate" Coilheads.
  - `ExplosionFire` - Enable green fire effect for Coilheads that are about to explode.
  - `ExplosionParticles` - Enable radioactive particles effect for Coilheads that are about to explode.
  - `ExplosionWarnVolume` - Adjust volume of the sound effect played right before exploding (**NOT** the actual explosion).
  - `EnableCoilheadScanNode` - Enable scanning Coilheads that have been killed.
  - `ModifyCoilheadScanNode` - Add extra text/subtext to a killed Coilhead's scan node (requires `EnableCoilheadScanNode`).
- Fixed "lore accurate" Coilhead particle effects not showing up after reloading a lobby once.