### PR TITLE
Reworked Jester counterplay, also a couple minor fixes.

### DIFF
--- a/Assets/CoillessCoilhead.prefab
+++ b/Assets/CoillessCoilhead.prefab
@@ -260,7 +260,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0

--- a/Assets/JesterSurface.prefab
+++ b/Assets/JesterSurface.prefab
@@ -1,0 +1,336 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2240671126594924217
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5195721626108057000}
+  - component: {fileID: 181099249156686775}
+  - component: {fileID: 996201985245098780}
+  - component: {fileID: 6566752859781180145}
+  m_Layer: 13
+  m_Name: bounds
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5195721626108057000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2240671126594924217}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0.008726558, z: 0, w: 0.999962}
+  m_LocalPosition: {x: -0.001, y: 0.6, z: -0.004}
+  m_LocalScale: {x: 0.75, y: 0, z: 0.75}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8241282283124717150}
+  m_LocalEulerAnglesHint: {x: 0, y: 1, z: 0}
+--- !u!33 &181099249156686775
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2240671126594924217}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &996201985245098780
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2240671126594924217}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 257
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6422e1e64ba8ace488b1b20c0ed33459, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &6566752859781180145
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2240671126594924217}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &3882220575088093631
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8241282283124717150}
+  - component: {fileID: 1756167210889195349}
+  - component: {fileID: 4268735223696473048}
+  - component: {fileID: 7163514940616469804}
+  - component: {fileID: 562615155570545708}
+  - component: {fileID: 4359371101906246141}
+  - component: {fileID: 2746889951097355958}
+  m_Layer: 9
+  m_Name: JesterSurface
+  m_TagString: InteractTrigger
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8241282283124717150
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882220575088093631}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.00053340715, y: -0.017028123, z: 0.0012517842, w: 0.9998541}
+  m_LocalPosition: {x: -0.017089844, y: 1.5862427, z: -0.040359497}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5195721626108057000}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: -1.499998, y: 1.0000018, z: 0.29999956}
+--- !u!33 &1756167210889195349
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882220575088093631}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4268735223696473048
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882220575088093631}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 257
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6422e1e64ba8ace488b1b20c0ed33459, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &7163514940616469804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882220575088093631}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 951099334
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+--- !u!65 &562615155570545708
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882220575088093631}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.2, y: 0.4, z: 1.2}
+  m_Center: {x: 0, y: 0.4, z: 0}
+--- !u!114 &4359371101906246141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882220575088093631}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 507293d35d7a13e5b9ca9bb60e082e11, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hoverIcon: {fileID: 21300000, guid: de67ca1a15339da408c158f6974e0d8c, type: 2}
+  hoverTip: Place item...? [LMB]
+  disabledHoverIcon: {fileID: 0}
+  disabledHoverTip: 
+  interactable: 1
+  oneHandedItemAllowed: 1
+  twoHandedItemAllowed: 1
+  holdInteraction: 1
+  timeToHold: 0.25
+  timeToHoldSpeedMultiplier: 1
+  holdTip: 
+  isBeingHeldByPlayer: 0
+  holdingInteractEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  touchTrigger: 0
+  triggerOnce: 0
+  interactCooldown: 1
+  cooldownTime: 1
+  currentCooldownValue: 0
+  disableTriggerMesh: 1
+  RandomChanceTrigger: 0
+  randomChancePercentage: 0
+  onInteractEarlyOtherClients:
+    m_PersistentCalls:
+      m_Calls: []
+  onInteract:
+    m_PersistentCalls:
+      m_Calls: []
+  onInteractEarly:
+    m_PersistentCalls:
+      m_Calls: []
+  onStopInteract:
+    m_PersistentCalls:
+      m_Calls: []
+  onCancelAnimation:
+    m_PersistentCalls:
+      m_Calls: []
+  specialCharacterAnimation: 0
+  stopAnimationManually: 0
+  stopAnimationString: SA_stopAnimation
+  hidePlayerItem: 0
+  isPlayingSpecialAnimation: 0
+  animationWaitTime: 2
+  animationString: 
+  lockPlayerPosition: 0
+  playerPositionNode: {fileID: 0}
+  clampLooking: 0
+  setVehicleAnimation: 0
+  minVerticalClamp: 0
+  maxVerticalClamp: 0
+  horizontalClamp: 0
+  allowUseWhileInAnimation: 0
+  overridePlayerParent: {fileID: 0}
+  isLadder: 0
+  topOfLadderPosition: {fileID: 0}
+  useRaycastToGetTopPosition: 0
+  bottomOfLadderPosition: {fileID: 0}
+  ladderHorizontalPosition: {fileID: 0}
+  ladderPlayerPositionNode: {fileID: 0}
+  usingLadder: 0
+--- !u!54 &2746889951097355958
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3882220575088093631}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Assets/JesterSurface.prefab.meta
+++ b/Assets/JesterSurface.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7571473c74ebe9b40beeda9e99e9cec6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: morecounterplayassets
+  assetBundleVariant: 

--- a/Behaviours/JesterSurface.cs
+++ b/Behaviours/JesterSurface.cs
@@ -1,0 +1,389 @@
+using GameNetcodeStuff;
+using HarmonyLib;
+using Unity.Netcode;
+using UnityEngine;
+using UnityEngine.Animations;
+
+namespace MoreCounterplay.Behaviours
+{
+	/// <summary>
+	/// 	Network behaviour script handling placing items on top of a Jester.
+	/// </summary>
+	public class JesterSurface : PlaceableObjectsSurface
+	{
+		/// <summary>
+		/// 	Prefab for the Jester surface container.
+		/// </summary>
+		public static GameObject? JesterSurfacePrefab { get; internal set; }
+
+		/// <summary>
+		/// 	Total weight of items on top of the Jester.
+		/// </summary>
+		/// <remarks>
+		/// 	Might not be 100% accurate with the weight of items shown in-game, due to rounding.
+		/// 	Weight from items that are destroyed or removed by other means will also remain until it resets to 0.
+		/// </remarks>
+		public float TotalWeight { get; internal set; } = 0f;
+
+		/// <summary>
+		/// 	Jester script instance the surface is parented to.
+		/// </summary>
+		public JesterAI? Jester { get; private set; }
+
+		public override void OnNetworkSpawn()
+		{
+			base.OnNetworkSpawn();
+
+			// Remove the '(Clone)' from the Jester surface instance.
+			transform.name = JesterSurfacePrefab?.name;
+
+			// Assign PlaceableObjectsSurface components.
+			parentTo = GetComponent<NetworkObject>();
+			placeableBounds = transform.Find("bounds").GetComponent<Collider>();
+			triggerScript = GetComponent<InteractTrigger>();
+
+			// Call 'JesterSurface.PlaceObject()' whenever the player finishes interacting with the Jester surface.
+			triggerScript.onInteract.AddListener(PlaceObject);
+		}
+
+		public void Start()
+		{
+			// Find and obtain parent Jester script.
+			if (transform.GetParent()?.TryGetComponent(out JesterAI jester) == true)
+			{
+				Jester = jester;
+			}
+
+			// Add Jester box as source and activate constraint to move alongside it.
+			ParentConstraint jesterConstraint = gameObject.AddComponent<ParentConstraint>();
+			jesterConstraint.AddSource(new()
+			{
+				weight = 1f,
+				sourceTransform = transform.GetParent().Find("MeshContainer/AnimContainer/metarig/BoxContainer")
+			});
+			jesterConstraint.constraintActive = true;
+		}
+
+		public new void Update()
+		{
+			if (triggerScript != null)
+			{
+				// Disable interacting with Jester surface if the local player is not holding an item, or if the Jester is active.
+				triggerScript.interactable = GameNetworkManager.Instance.localPlayerController.isHoldingObject && Jester?.currentBehaviourStateIndex != 2;
+			}
+		}
+
+		/// <summary>
+		/// 	Place the currently held object on top of the Jester surface.
+		/// </summary>
+		/// <param name="playerWhoTriggered">The player placing the item.</param>
+		public new void PlaceObject(PlayerControllerB playerWhoTriggered)
+		{
+			if (!playerWhoTriggered.IsOwner) return;
+
+			// Return if the local player is not holding an item.
+			if (!playerWhoTriggered.isHoldingObject || playerWhoTriggered.isGrabbingObjectAnimation || playerWhoTriggered.currentlyHeldObjectServer == null) return;
+
+			// Obtain item to place on top of the Jester.
+			GrabbableObject item = playerWhoTriggered.currentlyHeldObjectServer;
+
+			// Obtain placement position and place object on top of the Jester.
+			Vector3 position = parentTo.transform.InverseTransformPoint(itemPlacementPosition(playerWhoTriggered.gameplayCamera.transform, item));
+			playerWhoTriggered.DiscardHeldObject(true, parentTo, position, false);
+
+			// Place item on top of the Jester on all clients.
+			PlaceItemOnClient(item);
+			PlaceItemServerRpc(playerWhoTriggered.GetComponent<NetworkObject>(), item.GetComponent<NetworkObject>());
+		}
+
+		/// <summary>
+		/// 	Obtain the closest point within the surface bounds that the camera is pointing to.
+		/// </summary>
+		/// <param name="camera">The local player camera.</param>
+		/// <param name="heldItem">The local player's currently held item.</param>
+		/// <returns>The Vector3 position at which to place the item.</returns>
+		public new Vector3 itemPlacementPosition(Transform camera, GrabbableObject heldItem)
+		{
+			// Layers: [8 (Room), 9 (InteractableObject), 11 (Colliders), 30 (Vehicle)] + 13 (Triggers) + 19 (Enemies).
+			int layerMask = 1073744640 + (1 << 13) + (1 << 19);
+
+			// Find and return closest point within the surface bounds that the player camera is aiming towards.
+			bool raycastHit = Physics.Raycast(camera.position, camera.forward, out RaycastHit hitInfo, 7f, layerMask, QueryTriggerInteraction.Ignore);
+			return !raycastHit ? placeableBounds.transform.position : (placeableBounds.ClosestPoint(hitInfo.point)
+				+ placeableBounds.transform.up * heldItem.itemProperties.verticalOffset);
+		}
+
+		/// <summary>
+		/// 	Reset the parent Jester's animations under certain circumstances.
+		/// </summary>
+		public void ResetJester()
+		{
+			if (Jester == null) return;
+
+			// Disable Jester encumbered state if its weight is past the 'encumber' threshold.
+			if (MoreCounterplay.Settings.JesterEncumberThreshold != 0 && TotalWeight < MoreCounterplay.Settings.JesterEncumberThreshold
+				&& Jester.stunNormalizedTimer > 0f)
+			{
+				Jester.beginCrankingTimer = Jester.stunNormalizedTimer * Jester.enemyType.stunTimeMultiplier;
+				Jester.stunNormalizedTimer = 0f;
+			}
+
+			// Disable Jester panicked state if its weight is past the 'panic' threshold.
+			if (MoreCounterplay.Settings.JesterPanicThreshold != 0 && TotalWeight < MoreCounterplay.Settings.JesterPanicThreshold
+				&& Jester.creatureAnimator.GetBool("turningCrank") && Jester.currentBehaviourStateIndex == 0)
+			{
+				Jester.creatureVoice.Stop();
+
+				Jester.creatureAnimator.SetBool("turningCrank", false);
+				Jester.creatureAnimator.SetFloat("CrankSpeedMultiplier", 1f);
+
+				Jester.creatureAnimator.CrossFade("IdleDocile", 0.1f);
+			}
+		}
+
+		/// <summary>
+		/// 	Place an item on top of the Jester on the local client.
+		/// </summary>
+		/// <param name="item">The item to place.</param>
+		public void PlaceItemOnClient(GrabbableObject item)
+		{
+			// Return if any PlaceableObjectsSurface component is missing.
+			if (parentTo == null || placeableBounds == null || triggerScript == null) return;
+
+			// Shouldn't be able to interact with the surface at all while the Jester is active, but checking here regardless.
+			if (Jester == null || Jester.currentBehaviourStateIndex == 2) return;
+
+			// Add a Rigidbody component to the item's scan node (if it doesn't already have one) in order for it to remain scannable while on top of the Jester.
+			if (item.transform.GetChild(0)?.TryGetComponent(out ScanNodeProperties itemScanNode) == true
+				&& !itemScanNode.TryGetComponent<Rigidbody>(out _))
+			{
+				// Fix obtained from: https://github.com/digger1213/CruiserImproved/blob/6159533fee9c5748ef667067a9cbb66ba5fa6237/source/Patches/PlayerController.cs#L45
+				itemScanNode.gameObject.AddComponent<Rigidbody>().isKinematic = true;
+			}
+
+			// Increment Jester's total weight by the weight of the placed item.
+			TotalWeight += (item.itemProperties.weight - 1f) * 105f;
+			MoreCounterplay.Log($"Current weight: {TotalWeight}");
+
+			// Update Jester scan node to include its total weight.
+			if (MoreCounterplay.Settings.ShowWeightOnScan && Jester.transform.Find("ScanNode")?.TryGetComponent(out ScanNodeProperties jesterScanNode) == true)
+			{
+				jesterScanNode.subText = $"Weight: {TotalWeight} lbs";
+			}
+
+			// Set Jester as stunned if its weight goes past the 'encumber' threshold, to prevent it from moving around.
+			if (MoreCounterplay.Settings.JesterEncumberThreshold > 0 && TotalWeight >= MoreCounterplay.Settings.JesterEncumberThreshold
+				&& Jester.stunNormalizedTimer <= 0f)
+			{
+				if (!Jester.creatureAnimator.GetBool("turningCrank"))
+				{
+					// Stun Jester for the same amount of time as the timer until cranking.
+					Jester.stunNormalizedTimer = Jester.beginCrankingTimer / Jester.enemyType.stunTimeMultiplier;
+					Jester.beginCrankingTimer *= 15f; // Timer until cranking decreases 15x as fast when the Jester is stunned.
+				}
+			}
+
+			// Enable Jester panicked state if its weight goes past the 'panic' threshold.
+			if (MoreCounterplay.Settings.JesterPanicThreshold > 0 && TotalWeight >= MoreCounterplay.Settings.JesterPanicThreshold)
+			{
+				// Enable Jester panicked state (if not already cranking).
+				if (!Jester.creatureAnimator.GetBool("turningCrank"))
+				{
+					// Play Jester ambient noise as a warning.
+					Jester.creatureVoice.clip = Jester.screamingSFX;
+					Jester.creatureVoice.Play();
+
+					// Enable frantic Jester cranking.
+					Jester.creatureAnimator.SetBool("turningCrank", true);
+					Jester.creatureAnimator.SetFloat("CrankSpeedMultiplier", 2.5f);
+
+					// Set timer until cranking to 5 seconds (at most), at which point it'll pop instantly if its weight is still higher than the 'panic' threshold.
+					Jester.beginCrankingTimer = Mathf.Clamp(Jester.beginCrankingTimer, MoreCounterplay.Settings.MinPanicTimer * 15f, MoreCounterplay.Settings.MaxPanicTimer * 15f);
+					Jester.stunNormalizedTimer = Jester.beginCrankingTimer / (Jester.enemyType.stunTimeMultiplier * 15f);
+				}
+				else
+				{
+					// Activate Jester immediately if an item is placed on it while cranking AND past the 'panic' threshold.
+					Jester.SwitchToBehaviourStateOnLocalClient(2);
+					Jester.stunNormalizedTimer = 0f;
+
+					DropAllItemsOnClient();
+				}
+			}
+		}
+
+		/// <summary>
+		/// 	Grab an item placed on top of the Jester on the local client.
+		/// </summary>
+		/// <param name="item">The item to grab.</param>
+		public void RemoveItemOnClient(GrabbableObject item)
+		{
+			// Return if any PlaceableObjectsSurface component is missing.
+			if (parentTo == null || placeableBounds == null || triggerScript == null) return;
+
+			// Shouldn't be able to interact with the surface at all while the Jester is active, but checking here regardless.
+			if (Jester == null || Jester.currentBehaviourStateIndex == 2) return;
+
+			TotalWeight -= (item.itemProperties.weight - 1f) * 105f;
+			MoreCounterplay.Log($"Current weight: {TotalWeight}");
+
+			// De-parent item from Jester surface.
+			item.transform.SetParent(StartOfRound.Instance.propsContainer, true);
+
+			if (MoreCounterplay.Settings.ShowWeightOnScan && Jester.transform.Find("ScanNode").TryGetComponent(out ScanNodeProperties scanNode) == true)
+			{
+				scanNode.subText = TotalWeight > 0 ? $"Weight: {TotalWeight} lbs" : "";
+			}
+
+			if (Jester.currentBehaviourStateIndex == 0)
+			{
+				ResetJester();
+			}
+		}
+
+		/// <summary>
+		/// 	Drop all items on top of the Jester on the local client.
+		/// </summary>
+		/// <param name="hit">Whether or not the Jester was hit instead of popping by itself (to reset animations).</param>
+		public void DropAllItemsOnClient(bool hit = false)
+		{
+			// Iterate for every item on top of the Jester.
+			GetComponentsInChildren<GrabbableObject>().Do(item =>
+			{
+				// De-parent item from Jester surface.
+				item.parentObject = null;
+				item.transform.SetParent(StartOfRound.Instance.propsContainer, true);
+
+				// Set placed item properties.
+				item.EnablePhysics(true);
+				item.EnableItemMeshes(true);
+				item.isHeld = false;
+				item.isPocketed = false;
+
+				// Set falling properties and start its fall.
+				item.startFallingPosition = StartOfRound.Instance.propsContainer.InverseTransformPoint(item.transform.position);
+				item.FallToGround(false);
+				item.fallTime = -0.3f;
+				item.hasHitGround = false;
+			});
+
+			// Clear Jester scan node's subtext, and reset its total weight.
+			if (Jester?.transform.Find("ScanNode")?.TryGetComponent(out ScanNodeProperties scanNode) == true)
+			{
+				scanNode.subText = "";
+			}
+			TotalWeight = 0.0f;
+
+			// Reset Jester animations if hit.
+			if (hit)
+			{
+				ResetJester();
+			}
+		}
+
+		/// <summary>
+		/// 	Handles TODO.
+		/// </summary>
+		/// <param name="panic"></param>
+		[ClientRpc]
+		public void PreventJesterPopClientRpc(bool panic = false)
+		{
+			if (Jester == null) return;
+
+			if (panic || !MoreCounterplay.Settings.ItemsStayOnLid)
+			{
+				// Show Jester's head for a brief moment before dropping items (cannot kill players).
+				Jester.creatureAnimator.CrossFade("JesterPopUp", 0.1f);
+				Jester.creatureVoice.Stop();
+
+				DropAllItemsOnClient();
+			}
+			else
+			{
+				// Transition from "JesterTurnCrank" state to "IdleDocile" state in 0.1 seconds.
+				Jester.creatureAnimator.CrossFade("IdleDocile", 0.1f);
+			}
+		}
+
+		/// <summary>
+		/// 	Place an item on top the Jester for all clients except the one who placed the item.
+		/// </summary>
+		/// <param name="playerReference">NetworkObject reference of the player who placed the item.</param>
+		/// <param name="itemReference">NetworkObject reference of the item to place.</param>
+		[ClientRpc]
+		public void PlaceItemClientRpc(NetworkObjectReference playerReference, NetworkObjectReference itemReference)
+		{
+			if (playerReference.TryGet(out NetworkObject playerNetworkObject) && playerNetworkObject.IsOwner) return;
+
+			if (itemReference.TryGet(out NetworkObject itemNetworkObject)
+				&& itemNetworkObject.TryGetComponent(out GrabbableObject item))
+			{
+				PlaceItemOnClient(item);
+			}
+		}
+
+		/// <summary>
+		/// 	TODO.
+		/// </summary>
+		/// <param name="playerReference">NetworkObject reference of the player who placed the item.</param>
+		/// <param name="itemReference">NetworkObject reference of the item to place.</param>
+		[ServerRpc(RequireOwnership = false)]
+		public void PlaceItemServerRpc(NetworkObjectReference playerReference, NetworkObjectReference itemReference)
+		{
+			PlaceItemClientRpc(playerReference, itemReference);
+		}
+
+
+		/// <summary>
+		/// 	Remove an item placed on top of the Jester for all clients except the one who grabbed the item.
+		/// </summary>
+		/// <param name="playerReference">NetworkObject reference of the player who grabbed the item</param>
+		/// <param name="itemReference">NetworkObject reference of the item to grab.</param>
+		[ClientRpc]
+		public void RemoveItemClientRpc(NetworkObjectReference playerReference, NetworkObjectReference itemReference)
+		{
+			if (playerReference.TryGet(out NetworkObject playerNetworkObject) && playerNetworkObject.IsOwner) return;
+
+			if (itemReference.TryGet(out NetworkObject itemNetworkObject)
+				&& itemNetworkObject.TryGetComponent(out GrabbableObject item))
+			{
+				RemoveItemOnClient(item);
+			}
+		}
+
+		/// <summary>
+		/// 	TODO.
+		/// </summary>
+		/// <param name="playerReference">NetworkObject reference of the player who placed the item.</param>
+		/// <param name="itemReference">NetworkObject reference of the item to place.</param>
+		[ServerRpc(RequireOwnership = false)]
+		public void RemoveItemServerRpc(NetworkObjectReference playerReference, NetworkObjectReference itemReference)
+		{
+			RemoveItemClientRpc(playerReference, itemReference);
+		}
+
+		/// <summary>
+		/// 	Drop all items on top of the Jester for all clients except the host, or all clients except the one who hit it.
+		/// </summary>
+		/// <param name="playerReference">NetworkObject reference of the host, or the player who hit the Jester.</param>
+		/// <param name="hit">Whether or not the Jester was hit instead of popping by itself (to reset animations).</param>
+		[ClientRpc]
+		public void DropAllItemsClientRpc(NetworkObjectReference playerReference, bool hit = false)
+		{
+			if (playerReference.TryGet(out NetworkObject playerNetworkObject) && playerNetworkObject.IsOwner) return;
+
+			DropAllItemsOnClient(hit);
+		}
+
+		/// <summary>
+		/// 	TODO.
+		/// </summary>
+		/// <param name="playerReference">NetworkObject reference of the host, or the player who hit the Jester.</param>
+		/// <param name="hit">Whether or not the Jester was hit instead of popping by itself (to reset animations).</param>
+		[ServerRpc(RequireOwnership = false)]
+		public void DropAllItemsServerRpc(NetworkObjectReference playerReference, bool hit = false)
+		{
+			DropAllItemsClientRpc(playerReference, hit);
+		}
+	}
+}

--- a/Behaviours/JesterSurface.cs
+++ b/Behaviours/JesterSurface.cs
@@ -282,20 +282,21 @@ namespace MoreCounterplay.Behaviours
 		}
 
 		/// <summary>
-		/// 	Handles TODO.
+		/// 	Handles switching a Jester's animation both when its pop is prevented and when it finishes panicking.
 		/// </summary>
-		/// <param name="panic"></param>
+		/// <param name="panic">Whether or not the Jester is in its panicked state.</param>
 		[ClientRpc]
-		public void PreventJesterPopClientRpc(bool panic = false)
+		public void SwitchAnimationClientRpc(bool panic = false)
 		{
 			if (Jester == null) return;
 
 			if (panic || !MoreCounterplay.Settings.ItemsStayOnLid)
 			{
-				// Show Jester's head for a brief moment before dropping items (cannot kill players).
+				// Show Jester's head for a brief moment before dropping items (cannot actually kill players unless it's panicking).
 				Jester.creatureAnimator.CrossFade("JesterPopUp", 0.1f);
 				Jester.creatureVoice.Stop();
 
+				// Drop all items on top of the Jester.
 				DropAllItemsOnClient();
 			}
 			else
@@ -323,7 +324,7 @@ namespace MoreCounterplay.Behaviours
 		}
 
 		/// <summary>
-		/// 	TODO.
+		/// 	Send 'JesterSurface.PlaceItemClientRpc()' call from the server to all clients.
 		/// </summary>
 		/// <param name="playerReference">NetworkObject reference of the player who placed the item.</param>
 		/// <param name="itemReference">NetworkObject reference of the item to place.</param>
@@ -352,7 +353,7 @@ namespace MoreCounterplay.Behaviours
 		}
 
 		/// <summary>
-		/// 	TODO.
+		/// 	Send 'JesterSurface.RemoveItemClientRpc()' call from the server to all clients.
 		/// </summary>
 		/// <param name="playerReference">NetworkObject reference of the player who placed the item.</param>
 		/// <param name="itemReference">NetworkObject reference of the item to place.</param>
@@ -376,7 +377,7 @@ namespace MoreCounterplay.Behaviours
 		}
 
 		/// <summary>
-		/// 	TODO.
+		/// 	Send 'JesterSurface.DropAllItemsClientRpc()' call from the server to all clients.
 		/// </summary>
 		/// <param name="playerReference">NetworkObject reference of the host, or the player who hit the Jester.</param>
 		/// <param name="hit">Whether or not the Jester was hit instead of popping by itself (to reset animations).</param>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,79 @@
 
 ## 1.4.0
 
+<ul>
+ <li>Reworked Jester counterplay:
+  <ul>
+   <li>
+    Items are now placed on top of a Jester by holding an item and interacting with its lid
+   </li>
+   <li>
+    After its pop is prevented, the Jester now drops all items on its head, forcing players to keep an eye out and make sure there's always items on top of it before it finishes cranking
+   </li>
+   <li>
+    Added some consequences for putting an excessive amount of weight on top of a Jester (configurable)
+   </li>
+   <li>
+    Hitting a Jester with a shovel now causes it to drop all items placed on top of it
+   </li>
+   <li>
+    Scanning a Jester now shows its total weight as its scan node's subtext
+   </li>
+   <li>
+    New features can be disabled in the config file, if so desired
+   </li>
+   <li>
+    <details>
+     <summary>Spoiler (specific mechanics and configuration):</summary>
+     <ul>
+      <li>Any grabbable item can be deposited onto a Jester by holding the interact button while the prompt to place an item is visible (similar to the Ship's storage cabinet, the Cruiser's back storage, and the desk at the Company)
+       <ul>
+        <li>Items can no longer be physically dropped on top of it, but this will likely be readded in the future</li>
+       </ul>
+      </li>
+      <li>If the Jester finishes cranking while its total weight exceeds the amount set by the <code>JesterPreventThreshold</code> setting (<b>60</b> pounds by default), its head visually pops out for a brief moment to drop its items before returning to its box, without actually chasing or killing players
+       <ul>
+        <li>Toggling the <code>ItemsStayOnLid</code> setting disables the Jester's ability to drop its items and keeps its head inside the box at all times, making it like how it used to work in previous versions of the mod</li>
+       </ul>
+      </li>
+      <li>If the Jester's total weight exceeds the amount set by the <code>JesterEncumberThreshold</code> setting (<b>120</b> pounds by default), it'll no longer be able to follow you around due to being encumbered by the items
+       <ul>
+        <li>Threshold setting can be set to <code>0</code> to disable the Jester's encumbered state completely, or a small value (e.g. <code>0.1</code>) to allow almost any item to stop the Jester from moving</li>
+       </ul>
+      </li>
+      <li>If the Jester's total weight exceeds the amount set by the <code>JesterPanicThreshold</code> setting (<b>200</b> pounds by default), it'll panic and begin cranking frantically before popping shortly after
+       <ul>
+        <li>Threshold setting can be set to <b>0</b> to disable the Jester's panicked state completely</li>
+        <li>Minimum and maximum time that the Jester spends panicking can be configured via the <code>MinPanicTimer</code> and <code>MaxPanicTimer</code> settings, respectively</li>
+        <li>Setting this threshold to a lower value than the <code>JesterPreventThreshold</code> setting functionally disables it as a counterplay, since the Jester's pop is not prevented while panicking</li>
+        <li>Placing an item while over the panic threshold and while the Jester is cranking (even normally) will cause it to <b>skip its cranking and pop immediately</b></li>
+       </ul>
+      </li>
+      <li>Whenever a Jester is hit by a shovel, it'll drop all its held items and reset its weight
+       <ul>
+        <li>Can be disabled by toggling the <code>DropItemsOnHit</code> setting</li>
+       </ul>
+      </li>
+      <li>The total amount of weight the Jester is carrying is shown in the subtext of its scan node
+       <ul>
+        <li>Can be disabled by toggling the <code>ShowWeightOnScan</code> setting</li>
+        <li>Might be slightly inaccurate due to integer rounding, or if an item is destroyed or otherwise removed by other means</li>
+       </ul>
+      </li>
+     </ul>
+    </details>
+   </li>
+  </ul>
+ </li>
+</ul>
+
+- Fixed Jester getting stuck on its cranking animation after its pop is prevented
+  - All animations should now be properly synced between all clients
 - "Coilless Coilhead" material texture is now obtained from the Coilhead right as it spawns
   - Should make it compatible with some [EnemySkinKit](https://thunderstore.io/c/lethal-company/p/AntlerShed/EnemySkinKit) skins that don't modify the Coilhead model too much (e.g. [ColorfulEnemyVariety](https://thunderstore.io/c/lethal-company/p/DistinctBlaze/ColorfulEnemyVariety))
   - Material texture persists until reloading the save file, at which point it'll return to the vanilla Coilhead texture
 - Fixed "Coilless Coilhead" item sound effects being heard globally by changing it from a 2D sound to a 3D one
+- Added more information to the mod description, as well as short gifs showcasing some features
 
 ## 1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.0
+
+- "Coilless Coilhead" material texture is now obtained from the Coilhead right as it spawns
+  - Should make it compatible with some [EnemySkinKit](https://thunderstore.io/c/lethal-company/p/AntlerShed/EnemySkinKit) skins that don't modify the Coilhead model too much (e.g. [ColorfulEnemyVariety](https://thunderstore.io/c/lethal-company/p/DistinctBlaze/ColorfulEnemyVariety))
+  - Material texture persists until reloading the save file, at which point it'll return to the vanilla Coilhead texture
+- Fixed "Coilless Coilhead" item sound effects being heard globally by changing it from a 2D sound to a 3D one
+
 ## 1.3.1
 
 - Added several client-sided configuration settings for "lore accurate" Coilheads

--- a/Config/ConfigSettings.cs
+++ b/Config/ConfigSettings.cs
@@ -13,7 +13,17 @@ namespace MoreCounterplay.Config
         #region Variables
         #region Jester
         [field: SyncedEntryField] public SyncedEntry<bool> EnableJesterCounterplay { get; private set; }
-        [field: SyncedEntryField] public SyncedEntry<float> WeightToPreventJester { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<float> JesterPreventThreshold { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<float> JesterEncumberThreshold { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<float> JesterPanicThreshold { get; private set; }
+
+        [field: SyncedEntryField] public SyncedEntry<float> MinPanicTimer { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<float> MaxPanicTimer { get; private set; }
+
+        [field: SyncedEntryField] public SyncedEntry<bool> ItemsStayOnLid { get; private set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> DropItemsOnHit { get; private set; }
+
+        [field: SyncedEntryField] public SyncedEntry<bool> ShowWeightOnScan { get; private set; }
         #endregion
 
         #region Turret
@@ -52,8 +62,18 @@ namespace MoreCounterplay.Config
             config.SaveOnConfigSet = false;
 
             #region Jester
-            EnableJesterCounterplay = config.BindSyncedEntry("Jester", "EnableJesterCounterplay", true, "Add counterplay for Jester.");
-            WeightToPreventJester = config.BindSyncedEntry("Jester", "WeightToPreventJester", 30f, "Weight of items needed to prevent Jester pop out.");
+            EnableJesterCounterplay = config.BindSyncedEntry("Jester", "EnableJesterCounterplay", true, "Add counterplay for Jesters. Required for all Jester settings under this.");
+            JesterPreventThreshold = config.BindSyncedEntry("Jester", "JesterPreventThreshold", 60f, "Minimum weight of items needed to prevent the Jester from popping. Set to 0 to disable.");
+            JesterEncumberThreshold = config.BindSyncedEntry("Jester", "JesterEncumberThreshold", 120f, "Minimum weight of items needed to prevent the Jester from walking at all. Set to 0 to disable. Can be smaller than the setting above.");
+            JesterPanicThreshold = config.BindSyncedEntry("Jester", "JesterPanicThreshold", 200f, "Minimum weight of items needed for the Jester to start panicking. Set to 0 to disable. Functionally disables counterplay if lower than the 'prevent' threshold.");
+
+            MinPanicTimer = config.BindSyncedEntry("Jester", "MinPanicTimer", 0.5f, "Shortest amount of time the Jester can panic for before popping.");
+            MaxPanicTimer = config.BindSyncedEntry("Jester", "MaxPanicTimer", 5f, "Largest amount of time the Jester can panic for before popping");
+
+            ItemsStayOnLid = config.BindSyncedEntry("Jester", "ItemsStayOnLid", false, "Allow items to stay on top of the Jester after preventing it from popping.");
+            DropItemsOnHit = config.BindSyncedEntry("Jester", "DropItemsOnHit", true, "Drop all items on top of the Jester when hitting it with a shovel.");
+
+            ShowWeightOnScan = config.BindSyncedEntry("Jester", "ShowWeightOnScan", true, "Shows the total weight on top of the Jester as the subtext of its scan node.");
             #endregion
 
             #region Turret

--- a/Items/HeadItem.cs
+++ b/Items/HeadItem.cs
@@ -64,6 +64,10 @@ namespace MoreCounterplay.Items
 				// Obtain Coilhead's head prefab.
 				GameObject originalHead = coilheadNetworkObject.transform.Find("SpringManModel/Head").gameObject;
 
+				// Obtain head material and assign it to the 'Coilless Coilhead' scrap item prefab.
+				Material headMaterial = originalHead.GetComponent<MeshRenderer>().material;
+				GetComponent<MeshRenderer>().material = headMaterial;
+
 				// Attach head scrap item to original head object.
 				AttachTo(originalHead);
 

--- a/MoreCounterplay.csproj
+++ b/MoreCounterplay.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>BaronDrakula.MoreCounterplay</AssemblyName>
         <Product>MoreCounterplay</Product>
         <!-- Change to whatever version you're currently on. -->
-        <Version>1.3.1</Version>
+        <Version>1.4.0</Version>
     </PropertyGroup>
 
     <!-- Project Properties -->

--- a/Patches/JesterPatch.cs
+++ b/Patches/JesterPatch.cs
@@ -107,7 +107,7 @@ namespace MoreCounterplay.Patches
         [HarmonyPrefix]
         private static void HitJester(EnemyAI __instance, PlayerControllerB playerWhoHit, int hitID = -1)
         {
-            if (!playerWhoHit.IsOwner || !MoreCounterplay.Settings.EnableJesterCounterplay) return;
+            if (playerWhoHit == null || !playerWhoHit.IsOwner || !MoreCounterplay.Settings.EnableJesterCounterplay) return;
             if (__instance.isEnemyDead || __instance.GetType() != typeof(JesterAI)) return;
 
             // Drop all items on all clients if the Jester is hit by a shovel.

--- a/Patches/JesterPatch.cs
+++ b/Patches/JesterPatch.cs
@@ -60,8 +60,8 @@ namespace MoreCounterplay.Patches
                         // Change behaviour state parameter to 2 to skip cranking.
                         stateIndex = 2;
 
-                        // Pop Jester on all clients.
-                        jesterSurface.PreventJesterPopClientRpc(panic: true);
+                        // Switch Jester animation state to "JesterPopUp".
+                        jesterSurface.SwitchAnimationClientRpc(panic: true);
                     }
                     break;
                 case 2:
@@ -73,8 +73,8 @@ namespace MoreCounterplay.Patches
                         // Change behaviour state parameter to 0 to prevent popping.
                         stateIndex = 0;
 
-                        // Prevent Jester from popping on all clients.
-                        jesterSurface.PreventJesterPopClientRpc();
+                        // Switch Jester animation state to "JesterPopUp", or "IdleDocile" if items will stay on its head.
+                        jesterSurface.SwitchAnimationClientRpc();
                     }
                     else
                     {

--- a/Patches/JesterPatch.cs
+++ b/Patches/JesterPatch.cs
@@ -1,6 +1,7 @@
+using GameNetcodeStuff;
 using HarmonyLib;
-using System.Collections.Generic;
-using System.Linq;
+using MoreCounterplay.Behaviours;
+using Unity.Netcode;
 using UnityEngine;
 
 namespace MoreCounterplay.Patches
@@ -10,105 +11,126 @@ namespace MoreCounterplay.Patches
     {
         [HarmonyPatch(typeof(JesterAI), nameof(JesterAI.Start))]
         [HarmonyPostfix]
-        public static void SpawnItemsCollider(JesterAI __instance)
+        public static void OnSpawn(JesterAI __instance)
         {
-            if (!MoreCounterplay.Settings.EnableJesterCounterplay) return;
-            AddHeadCollider(__instance, "HeadCollider");
+            if ((!__instance.IsServer && !__instance.IsHost) || !MoreCounterplay.Settings.EnableJesterCounterplay) return;
+
+            if (JesterSurface.JesterSurfacePrefab == null)
+            {
+                MoreCounterplay.LogWarning("Jester surface prefab did not load correctly or is missing; its counterplay will not work.");
+                return;
+            }
+
+            // Create Jester surface prefab instance.
+            GameObject jesterSurfaceContainer = Object.Instantiate(JesterSurface.JesterSurfacePrefab);
+            jesterSurfaceContainer.name = JesterSurface.JesterSurfacePrefab.name;
+
+            if (!jesterSurfaceContainer.TryGetComponent(out NetworkObject networkSurface))
+            {
+                return;
+            }
+
+            // Spawn Jester surface NetworkObject.
+            networkSurface.Spawn();
+
+            // Set Jester surface instance as a child of its respective Jester.
+            jesterSurfaceContainer.transform.SetParent(__instance.transform, false);
         }
 
         [HarmonyPatch(typeof(EnemyAI), nameof(EnemyAI.SwitchToBehaviourState))]
         [HarmonyPrefix]
-        public static bool CheckJesterHead(EnemyAI __instance, int stateIndex)
+        public static void CheckJesterHead(EnemyAI __instance, ref int stateIndex)
         {
-            if (!MoreCounterplay.Settings.EnableJesterCounterplay) return true;
-            if (__instance.GetType() != typeof(JesterAI)) return true;
+            if ((!__instance.IsServer && !__instance.IsHost) || !MoreCounterplay.Settings.EnableJesterCounterplay) return;
+            if (__instance.GetType() != typeof(JesterAI)) return;
 
-            float weight = Mathf.RoundToInt(Mathf.Clamp(__instance.GetComponentInChildren<JesterHeadTrigger>().GetObjectsWeight(), 0f, 100f) * 105f);
+            // Find and obtain JesterSurface component.
+            if (__instance.transform.Find("JesterSurface")?.TryGetComponent(out JesterSurface jesterSurface) != true) return;
 
-            if (stateIndex == 2 && weight >= MoreCounterplay.Settings.WeightToPreventJester)
+            // Check which behaviour state the Jester is about to switch to.
+            switch (stateIndex)
             {
-                PreventJesterPopOut((JesterAI)__instance);
-                return false;
-            }
+                case 0:
+                case 1:
+                    // Pop Jester immediately if cranking while over the 'panic' threshold.
+                    if (MoreCounterplay.Settings.JesterPanicThreshold > 0 && jesterSurface.TotalWeight >= MoreCounterplay.Settings.JesterPanicThreshold)
+                    {
+                        MoreCounterplay.Log("Uh oh...");
 
-            if (stateIndex == 2 && weight < MoreCounterplay.Settings.WeightToPreventJester)
-            {
-                __instance.GetComponentInChildren<JesterHeadTrigger>().DropAllItems();
-                return true;
-            }
+                        // Change behaviour state parameter to 2 to skip cranking.
+                        stateIndex = 2;
 
-            return true;
-        }
+                        // Pop Jester on all clients.
+                        jesterSurface.PreventJesterPopClientRpc(panic: true);
+                    }
+                    break;
+                case 2:
+                    // Prevent Jester from popping if its weight goes past the 'prevent' threshold.
+                    if (MoreCounterplay.Settings.JesterPreventThreshold > 0 && jesterSurface.TotalWeight >= MoreCounterplay.Settings.JesterPreventThreshold)
+                    {
+                        MoreCounterplay.Log("Preventing Jester from popping...");
 
-        public static void PreventJesterPopOut(JesterAI __instance)
-        {
-            MoreCounterplay.Log($"Jester pop out prevented");
-            __instance.farAudio.Stop();
-            __instance.creatureAnimator.SetFloat("CrankSpeedMultiplier", 1f);
-            __instance.creatureAnimator.CrossFade(-51691287, .1f);
-            __instance.SwitchToBehaviourState(0);
-        }
+                        // Change behaviour state parameter to 0 to prevent popping.
+                        stateIndex = 0;
 
-        public static GameObject AddHeadCollider(JesterAI __instance, string name)
-        {
-            GameObject headCollider = new(name, typeof(BoxCollider));
-            headCollider.transform.SetParent(__instance.GetComponentsInChildren<Transform>().FirstOrDefault(child => child.name == "MeshContainer"));
-            headCollider.transform.localPosition = new Vector3(-.004f, 2.1f, .1171f);
-            headCollider.transform.localRotation = Quaternion.identity;
-
-            // v56 made 'GrabbableObject' items exclude the 'Colliders' layer.
-            headCollider.layer = LayerMask.NameToLayer("Enemies");
-
-            headCollider.GetComponent<BoxCollider>().center = Vector3.zero;
-            headCollider.GetComponent<BoxCollider>().size = new Vector3(.9698f, .1f, 1.4889f);
-            headCollider.GetComponent<BoxCollider>().isTrigger = true;
-            headCollider.AddComponent<JesterHeadTrigger>();
-            return headCollider;
-        }
-    }
-
-    internal class JesterHeadTrigger : MonoBehaviour
-    {
-        private readonly List<GrabbableObject> _objectsOnHead = [];
-
-        public float GetObjectsWeight()
-        {
-            float weight = 0f;
-
-            // Remove all objects that match from the list.
-            int itemsRemoved = _objectsOnHead.RemoveAll((GrabbableObject item) => item.parentObject != transform);
-            MoreCounterplay.Log($"{itemsRemoved} objects removed from Jester's head");
-
-            _objectsOnHead.ForEach(obj => weight += Mathf.Clamp(obj.itemProperties.weight - 1f, 0f, 10f));
-            return weight;
-        }
-
-        public void DropAllItems()
-        {
-            MoreCounterplay.Log($"Drop all items from Jester");
-            foreach (GrabbableObject item in _objectsOnHead)
-            {
-                _objectsOnHead.Remove(item);
-                item.FallToGround();
-                item.parentObject = null;
+                        // Prevent Jester from popping on all clients.
+                        jesterSurface.PreventJesterPopClientRpc();
+                    }
+                    else
+                    {
+                        // Drop all items on all clients if the Jester finished cranking while its weight is under the 'prevent' threshold.
+                        jesterSurface.DropAllItemsOnClient();
+                        jesterSurface.DropAllItemsServerRpc(GameNetworkManager.Instance.localPlayerController.GetComponent<NetworkObject>());
+                    }
+                    break;
+                default:
+                    break;
             }
         }
 
-        private void OnTriggerEnter(Collider collision)
+        [HarmonyPatch(typeof(GrabbableObject), nameof(GrabbableObject.GrabItem))]
+        [HarmonyPrefix]
+        public static void GrabItem(GrabbableObject __instance)
         {
-            if (!collision.CompareTag("PhysicsProp")) return;
+            if (!__instance.IsOwner || !MoreCounterplay.Settings.EnableJesterCounterplay) return;
 
-            if (collision.TryGetComponent(out GrabbableObject grabbableObject))
+            // Find and obtain JesterSurface component.
+            if (__instance.transform.GetParent()?.TryGetComponent(out JesterSurface jesterSurface) != true) return;
+
+            // Remove item from the Jester on all clients.
+            jesterSurface.RemoveItemOnClient(__instance);
+            jesterSurface.RemoveItemServerRpc(GameNetworkManager.Instance.localPlayerController.GetComponent<NetworkObject>(),
+                __instance.GetComponent<NetworkObject>());
+        }
+
+        [HarmonyPatch(typeof(EnemyAI), nameof(EnemyAI.HitEnemy))]
+        [HarmonyPrefix]
+        private static void HitJester(EnemyAI __instance, PlayerControllerB playerWhoHit, int hitID = -1)
+        {
+            if (!playerWhoHit.IsOwner || !MoreCounterplay.Settings.EnableJesterCounterplay) return;
+            if (__instance.isEnemyDead || __instance.GetType() != typeof(JesterAI)) return;
+
+            // Drop all items on all clients if the Jester is hit by a shovel.
+            if (__instance.currentBehaviourStateIndex != 2 && hitID == 1 && MoreCounterplay.Settings.DropItemsOnHit
+                && __instance.transform.Find("JesterSurface")?.TryGetComponent(out JesterSurface jesterSurface) == true)
             {
-                // Check if item is inside the ship, or on the ground. Should prevent Jester stealing items if it goes under the ship.
-                if (grabbableObject.isInShipRoom || grabbableObject.reachedFloorTarget)
-                {
-                    return;
-                }
+                jesterSurface.DropAllItemsOnClient(hit: true);
+                jesterSurface.DropAllItemsServerRpc(playerWhoHit.GetComponent<NetworkObject>(), hit: true);
+            }
+        }
 
-                MoreCounterplay.Log($"Add object to Jester's head {grabbableObject.name}");
-                grabbableObject.parentObject = transform;
-                if (!_objectsOnHead.Contains(grabbableObject)) _objectsOnHead.Add(grabbableObject);
+        [HarmonyPatch(typeof(EnemyAI), nameof(EnemyAI.KillEnemy))]
+        [HarmonyPrefix]
+        private static void KillJester(EnemyAI __instance)
+        {
+            if (!__instance.IsOwner || !MoreCounterplay.Settings.EnableJesterCounterplay) return;
+            if (__instance.isEnemyDead || __instance.GetType() != typeof(JesterAI)) return;
+
+            // Drop all items if 'EnemyAI.KillEnemy()' is ever called on a Jester (by another mod).
+            if (__instance.transform.Find("JesterSurface")?.TryGetComponent(out JesterSurface jesterSurface) == true)
+            {
+                jesterSurface.DropAllItemsOnClient(hit: true);
+                jesterSurface.DropAllItemsServerRpc(GameNetworkManager.Instance.localPlayerController.GetComponent<NetworkObject>(), hit: true);
             }
         }
     }

--- a/Patches/LoadPatches.cs
+++ b/Patches/LoadPatches.cs
@@ -23,7 +23,7 @@ namespace MoreCounterplay.Patches
             Object.Destroy(CoilExplosion.CoilheadPrefab?.GetComponent<CoilExplosion>());
 
             // Reset Coilhead prefab to vanilla values.
-            if (CoilExplosion.CoilheadPrefab?.TryGetComponent(out SpringManAI coilhead) ?? false)
+            if (CoilExplosion.CoilheadPrefab?.TryGetComponent(out SpringManAI coilhead) == true)
             {
                 coilhead.enemyHP = 3;
                 coilhead.enemyType.canDie = false;
@@ -81,7 +81,7 @@ namespace MoreCounterplay.Patches
                 else
                 {
                     LogWarning("Either the 'Coilless Coilhead' prefab did not load or the Coilhead enemy prefab could not be found. "
-                        + "Either way, some stuff might not load or work properly.");
+                        + "Some stuff might not load or work properly.");
                 }
             }
 
@@ -97,7 +97,7 @@ namespace MoreCounterplay.Patches
                 else
                 {
                     LogWarning("Either the 'RadioactiveFire' prefab did not load or the Forest Giant enemy prefab could not be found. "
-                        + "Either way, some stuff might not load or work properly.");
+                        + "Some stuff might not load or work properly.");
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,58 @@ Mod is fully configurable so you can disable or edit counterplays that you don't
 ### Jester
 
 <details>
- <summary>Spoiler</summary>
- You can prevent Jester from opening by putting heavy items on top of it.
+<summary>Spoiler</summary>
 
- ![A Jester carrying a big bolt on its head.](https://i.imgur.com/QcykrPl.jpg)
+Items may be placed on top of a Jester by holding an item and interacting with its lid, it'll carry them around until the next time it pops. If the total weight of items on its head exceeds a certain (configurable) amount, the Jester will be too exhausted to chase you after popping and its head will return to its box immediately.
+
+<div style="text-align: center;">
+ <img alt="A lamp being placed on top of a Jester." src="https://files.catbox.moe/1snzdi.gif" width=256>
+ <img alt="A Jester with several items on its head popping and returning to its box immediately." src="https://files.catbox.moe/dpvi2u.gif" width=256>
+ <h2 style="font-weight: bold; color: firebrick; text-shadow: 0 0 3px black">— [Warning] —</h2>
+
+ > Expecting a Jester to comply with carrying an excessive amount of weight may lead to disastrous consequences, as a desperate Jester's pop is much stronger than normal.
+
+ **Hint:** _A Jester <u>will</u> let you know when you've exceeded its limits, but there's still a short window to correct your mistake..._
+
+ <img alt="A Jester with an anvil on its head chasing and killing the player after popping." src="https://files.catbox.moe/qpse3i.gif" width=256>
+
+ <details>
+ <summary>Spoiler (specific mechanics and configuration):</summary>
+
+ <div style="text-align: left;">
+
+- Any grabbable item can be deposited onto a Jester by holding the interact button while the prompt to place an item is visible (similar to the Ship's storage cabinet, the Cruiser's back storage, and the desk at the Company).
+  - Every placed item's weight is added to the Jester's total weight, which forms the basis for its counterplay.
+- If the Jester finishes cranking while its total weight exceeds the amount set by the `JesterPreventThreshold` setting (**60** pounds by default), its head visually pops out for a brief moment to drop its items before returning to its box, without actually chasing or killing players.
+  - Toggling the `ItemsStayOnLid` setting disables the Jester's ability to drop its items and keeps its head inside the box at all times, making it like how it used to work in previous versions of the mod.
+- If the Jester's total weight exceeds the amount set by the `JesterEncumberThreshold` setting (**120** pounds by default), it'll no longer be able to follow you around due to being encumbered by the items.
+  - Threshold setting can be set to `0` to disable the Jester's encumbered state completely, or a small value (e.g. `0.1`) to allow almost any item to stop the Jester from moving.
+- If the Jester's total weight exceeds the amount set by the `JesterPanicThreshold` setting (**200** pounds by default), it'll panic and begin cranking frantically before popping shortly after.
+  - Threshold setting can be set to `0` to disable the Jester's panicked state completely.
+  - Minimum and maximum time that the Jester spends panicking can be configured via the `MinPanicTimer` and `MaxPanicTimer` settings, respectively.
+  - Setting this threshold to a lower value than the `JesterPreventThreshold` setting functionally disables it as a counterplay, since the Jester's pop is not prevented while panicking.
+  - Placing an item while over the panic threshold and while the Jester is cranking (even normally) will cause it to **skip its cranking and pop immediately**.
+- Whenever a Jester is hit by a shovel, it'll drop all its held items and reset its weight.
+  - Can be disabled by toggling the `DropItemsOnHit` setting.
+- The total amount of weight the Jester is carrying is shown in the subtext of its scan node.
+  - Can be disabled by toggling the `ShowWeightOnScan` setting.
+  - Might be slightly inaccurate due to integer rounding, or if an item is destroyed or otherwise removed by other means.
+
+ </div>
+ </details>
+</div>
 </details>
 
 <details>
  <summary>Configs</summary>
 
-- `EnableJesterCounterplay` - Add counterplay for Jester.
-- `WeightToPreventJester` - Weight of items needed to prevent Jester pop out.
+- `EnableJesterCounterplay` - Add counterplay for Jesters.
+- `JesterPreventThreshold` - Minimum weight of items needed to prevent the Jester from popping.
+- `JesterEncumberThreshold` - Minimum weight of items needed to prevent the Jester from walking at all.
+- `JesterPanicThreshold` - See above for more info.
+- `ItemsStayOnLid` - Allow items to stay on top of the Jester after preventing it from popping.
+- `DropItemsOnHit` - Drop all items on top of the Jester when hitting it with a shovel.
+- `ShowWeightOnScan` - Shows the total weight on top of the Jester as the subtext of its scan node.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -48,16 +48,18 @@ Mod is fully configurable so you can disable or edit counterplays that you don't
 <details>
 <summary>Spoiler</summary>
 
-You can cut off a Coilhead's head using a knife. Its head will become a scrap item and can be grabbed and sold, though you must detach it.
+You can cut off a Coilhead's head using the [Knife](https://lethal.miraheze.org/wiki/Kitchen_knife) dropped by the [Butler](https://lethal.miraheze.org/wiki/Butler), which deactivates it permanently. Its head will drop as a scrap item that can be sold to the Company, but it must first be detached from its neck.
 
 <div style="text-align: center;">
- <img alt="A decapitated Coilhead." src="https://i.imgur.com/WtcAkJ9.jpg" width=256>
- <img alt="A 'Coilless Coilhead' on the ground." src="https://i.imgur.com/LvhsWHD.jpg" width=256>
+ <img alt="A player chopping off a Coilhead's head and picking it up." src="https://files.catbox.moe/wvogrm.gif" width=256>
+ <img alt="A player trapped in a room by a deactivated Coilhead blocking the door, about to be killed by a Jester." src="https://files.catbox.moe/p1tbqj.gif" width=256>
  <h2 style="font-weight: bold; color: firebrick; text-shadow: 0 0 3px black">— [Warning] —</h2>
 
  > _"They have been known to combust into flames when being dissected or even deactivated, and they carry dangerously high levels of radioactive particles."_ - Sigurd's notes
 
  **Hint:** _You may find a Coilhead to be less volatile the more kinetic energy it releases when coming to a halt..._
+
+ <img alt="A player chopping off a Coilhead's head, picking it up, and then dying due to being too close to the explosion." src="https://files.catbox.moe/bvxtxg.gif" width=256>
 
  <details>
  <summary>Spoiler (specific mechanics and configuration):</summary>
@@ -65,19 +67,19 @@ You can cut off a Coilhead's head using a knife. Its head will become a scrap it
  <div style="text-align: left;">
 
 - Coilhead bodies combust upon being decapitated, as their Bestiary entry suggests
-  - Can be disabled by toggling the `LoreAccurateCoilheads` setting
-  - The range of the explosion damage is determined by the `ExplosionDamageRadius` setting, with the damage itself being set to the value of the `ExplosionDamage` setting
-  - Likewise, the `ExplosionKillRadius` setting determines the range around the explosion where it simply kills the player instead of dealing damage to them
-- Explosion timer is set to how long the Coilhead has moved since it last stopped, within configurable limits
+  - Can be disabled by toggling the `LoreAccurateCoilheads` setting.
+  - The range of the explosion damage is determined by the `ExplosionDamageRadius` setting, with the damage itself being set to the value of the `ExplosionDamage` setting.
+  - Likewise, the `ExplosionKillRadius` setting determines the range around the explosion where it simply kills the player instead of dealing damage to them.
+- Explosion timer is set to how long the Coilhead has moved since it last stopped, within configurable limits.
   - Minimum and maximum time until exploding can be configured via the `MinExplosionTimer` and `MaxExplosionTimer` settings, respectively
-- Coilhead's head item is destroyed if its body explodes while it's still attached to its neck
-  - Can be disabled by toggling the `ExplosionDestroysHead` setting, but it adds some interesting risk/reward by making players stay close to try and pick up the head before it explodes
+- Coilhead's head item is destroyed if its body explodes while it's still attached to its neck.
+  - Can be disabled by toggling the `ExplosionDestroysHead` setting, but it adds some interesting risk/reward by making players stay close to try and pick up the head before it explodes.
 - Client-side configuration settings:
-  - `ExplosionFire` - Enable green fire effect for Coilheads that are about to explode
-  - `ExplosionParticles` - Enable radioactive particles effect for Coilheads that are about to explode
-  - `ExplosionWarnVolume` - Adjust volume of the sound effect played right before exploding (**NOT** the actual explosion)
-  - `EnableCoilheadScanNode` - Enable scanning Coilheads that have been killed
-  - `ModifyCoilheadScanNode` - Add extra text/subtext to a killed Coilhead's scan node (requires `EnableCoilheadScanNode`)
+  - `ExplosionFire` - Enable green fire effect for Coilheads that are about to explode.
+  - `ExplosionParticles` - Enable radioactive particles effect for Coilheads that are about to explode.
+  - `ExplosionWarnVolume` - Adjust volume of the sound effect played right before exploding (**NOT** the actual explosion).
+  - `EnableCoilheadScanNode` - Enable scanning Coilheads that have been killed.
+  - `ModifyCoilheadScanNode` - Add extra text/subtext to a killed Coilhead's scan node (requires `EnableCoilheadScanNode`).
 
  </div>
  </details>

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Mod is fully configurable so you can disable or edit counterplays that you don't
 Items may be placed on top of a Jester by holding an item and interacting with its lid, it'll carry them around until the next time it pops. If the total weight of items on its head exceeds a certain (configurable) amount, the Jester will be too exhausted to chase you after popping and its head will return to its box immediately.
 
 <div style="text-align: center;">
- <img alt="A lamp being placed on top of a Jester." src="https://files.catbox.moe/1snzdi.gif" width=256>
- <img alt="A Jester with several items on its head popping and returning to its box immediately." src="https://files.catbox.moe/dpvi2u.gif" width=256>
+ <img alt="A lamp being placed on top of a Jester." src="https://files.catbox.moe/jkqrv8.gif" width=256>
+ <img alt="A Jester with several items on its head popping and returning to its box immediately." src="https://files.catbox.moe/49ut0j.gif" width=256>
  <h2 style="font-weight: bold; color: firebrick; text-shadow: 0 0 3px black">— [Warning] —</h2>
 
  > Expecting a Jester to comply with carrying an excessive amount of weight may lead to disastrous consequences, as a desperate Jester's pop is much stronger than normal.
 
  **Hint:** _A Jester <u>will</u> let you know when you've exceeded its limits, but there's still a short window to correct your mistake..._
 
- <img alt="A Jester with an anvil on its head chasing and killing the player after popping." src="https://files.catbox.moe/qpse3i.gif" width=256>
+ <img alt="A Jester with an anvil on its head chasing and killing the player after popping." src="https://files.catbox.moe/2cebnk.gif" width=256>
 
  <details>
  <summary>Spoiler (specific mechanics and configuration):</summary>
@@ -92,15 +92,15 @@ Items may be placed on top of a Jester by holding an item and interacting with i
 You can cut off a Coilhead's head using the [Knife](https://lethal.miraheze.org/wiki/Kitchen_knife) dropped by the [Butler](https://lethal.miraheze.org/wiki/Butler), which deactivates it permanently. Its head will drop as a scrap item that can be sold to the Company, but it must first be detached from its neck.
 
 <div style="text-align: center;">
- <img alt="A player chopping off a Coilhead's head and picking it up." src="https://files.catbox.moe/wvogrm.gif" width=256>
- <img alt="A player trapped in a room by a deactivated Coilhead blocking the door, about to be killed by a Jester." src="https://files.catbox.moe/p1tbqj.gif" width=256>
+ <img alt="A player chopping off a Coilhead's head and picking it up." src="https://files.catbox.moe/2k34ho.gif" width=256>
+ <img alt="A player trapped in a room by a deactivated Coilhead blocking the door, about to be killed by a Jester." src="https://files.catbox.moe/uqq80x.gif" width=256>
  <h2 style="font-weight: bold; color: firebrick; text-shadow: 0 0 3px black">— [Warning] —</h2>
 
  > _"They have been known to combust into flames when being dissected or even deactivated, and they carry dangerously high levels of radioactive particles."_ - Sigurd's notes
 
  **Hint:** _You may find a Coilhead to be less volatile the more kinetic energy it releases when coming to a halt..._
 
- <img alt="A player chopping off a Coilhead's head, picking it up, and then dying due to being too close to the explosion." src="https://files.catbox.moe/bvxtxg.gif" width=256>
+ <img alt="A player chopping off a Coilhead's head, picking it up, and then dying due to being too close to the explosion." src="https://files.catbox.moe/7ij65e.gif" width=256>
 
  <details>
  <summary>Spoiler (specific mechanics and configuration):</summary>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "MoreCounterplay",
-  "version_number": "1.3.1",
+  "version_number": "1.4.0",
   "website_url": "https://github.com/karyol/More-Counterplay-Mod",
   "description": "More counterplay for some Lethal Company mobs",
   "dependencies": [


### PR DESCRIPTION
## [1.4.0]
- Reworked Jester counterplay:
	- Items are now placed on top of a Jester by holding an item and interacting with its lid.
	- After its pop is prevented, the Jester now drops all items on its head, forcing players to keep an eye out and make sure there's always items on top of it before it finishes cranking.
	- Added some consequences for putting an excessive amount of weight on top of a Jester (configurable).
	- Hitting a Jester with a shovel now causes it to drop all items placed on top of it.
	- Scanning a Jester now shows its total weight as its scan node's subtext.
- Fixed Jester getting stuck on its cranking animation after its pop is prevented.
	- All animations should now be properly synced between all clients.
	- #5
- "Coilless Coilhead" material texture is now obtained from the Coilhead right as it spawns.
	- Should make it compatible with some [EnemySkinKit](https://thunderstore.io/c/lethal-company/p/AntlerShed/EnemySkinKit) skins that don't modify the Coilhead model too much (e.g. [ColorfulEnemyVariety](https://thunderstore.io/c/lethal-company/p/DistinctBlaze/ColorfulEnemyVariety)).
	- Material texture persists until reloading the save file, at which point it'll return to the vanilla Coilhead texture.
- Fixed "Coilless Coilhead" item sound effects being heard globally by changing it from a 2D sound to a 3D one.
- Updated AssetBundle once more to include the "Coilless Coilhead" audio fix and the new Jester surface prefab:
	- [morecounterplayassets_v1.4.0.zip](https://github.com/user-attachments/files/17084126/morecounterplayassets_v1.4.0.zip)
- Added more information to the mod description, as well as short gifs showcasing some features.